### PR TITLE
feat: add confirmation dialog when leaving rooms

### DIFF
--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -5,6 +5,7 @@ import { doc, onSnapshot, Timestamp } from 'firebase/firestore';
 import { chatroomsCol } from 'src/boot/firebase';
 import OverlappingAvatars from 'src/components/OverlappingAvatars.vue';
 import { useRoom } from 'src/composables/room';
+import ConfirmLeaveRoomDialog from './ConfirmLeaveRoomDialog.vue';
 
 const router = useRouter();
 const props = defineProps<{
@@ -77,8 +78,14 @@ const truncateMessage = (
   return text.substring(0, maxLength) + '...';
 };
 
+const showConfirmDialog = ref(false);
+
 const handleLeaveRoom = async (event: Event) => {
   event.stopPropagation();
+  showConfirmDialog.value = true;
+};
+
+const confirmLeave = async () => {
   if (!props.id) return;
 
   try {
@@ -144,4 +151,5 @@ onUnmounted(() => {
       </div>
     </q-item-section>
   </q-item>
+  <ConfirmLeaveRoomDialog v-model="showConfirmDialog" @confirm="confirmLeave" />
 </template>

--- a/src/components/ConfirmLeaveRoomDialog.vue
+++ b/src/components/ConfirmLeaveRoomDialog.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const showDialog = ref(false);
+</script>
+
+<template>
+  <q-dialog v-model="showDialog">
+    <q-card>
+      <q-card-section>
+        <div class="text-h6">Leave Room</div>
+      </q-card-section>
+      <q-card-section>
+        <div class="text-body1">Are you sure you want to leave this room?</div>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat label="Cancel" v-close-popup />
+        <q-btn color="primary" label="Leave" v-close-popup />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>

--- a/src/components/ConfirmLeaveRoomDialog.vue
+++ b/src/components/ConfirmLeaveRoomDialog.vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed } from 'vue';
 
-const showDialog = ref(false);
+const props = defineProps<{
+  modelValue: boolean;
+}>();
+
+const emits = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'confirm'): void;
+}>();
+
+const showDialog = computed({
+  get: () => props.modelValue,
+  set: (value) => emits('update:modelValue', value),
+});
 </script>
 
 <template>
-  <q-dialog v-model="showDialog">
+  <q-dialog v-model="showDialog" persistent>
     <q-card>
       <q-card-section>
         <div class="text-h6">Leave Room</div>
@@ -15,7 +27,12 @@ const showDialog = ref(false);
       </q-card-section>
       <q-card-actions align="right">
         <q-btn flat label="Cancel" v-close-popup />
-        <q-btn color="primary" label="Leave" v-close-popup />
+        <q-btn
+          color="negative"
+          label="Leave"
+          @click="emits('confirm')"
+          v-close-popup
+        />
       </q-card-actions>
     </q-card>
   </q-dialog>


### PR DESCRIPTION
# Add confirmation dialog when leaving rooms

## Changes
- Add confirmation dialog component with v-model support
- Implement two-way binding for dialog visibility
- Add proper event handling for confirmation
- Update ChatListItem to use confirmation flow
- Make dialog persistent to prevent accidental dismissal

## Why
Currently, users can accidentally leave a room with a single click. This can lead to:
- Unintended room exits
- Loss of chat history access
- Need to rejoin rooms
- Poor user experience

## Implementation Details
- Created reusable ConfirmLeaveRoomDialog component
- Added TypeScript types for props and events
- Implemented v-model pattern for dialog control
- Added persistent prop to prevent click-away dismissal
- Used negative color for leave button to indicate destructive action