### PR TITLE
feat: add private room indicator badge

### DIFF
--- a/src/components/ChatListItem.vue
+++ b/src/components/ChatListItem.vue
@@ -127,6 +127,14 @@ onUnmounted(() => {
             text-color="white"
             label="Public"
           />
+          <q-chip
+            v-if="roomData && roomData.private"
+            dense
+            size="sm"
+            color="pink-5"
+            label="Private"
+            outline
+          />
         </div>
         <div class="text-caption text-grey">
           <template v-if="roomData?.latestMessage">


### PR DESCRIPTION
# Add visual indicator for private rooms

## Changes
- Add private room chip with outline style
- Keep consistent styling with public badge
- Use pink-5 color scheme for room badges
- Add visual distinction between room types
- Improve room status visibility

## Why
Currently, there's no clear visual indication of a room's privacy status. This can lead to:
- Confusion about room accessibility
- Unclear room permissions
- Poor user experience when managing rooms
- Inconsistent visual feedback

## Implementation Details
- Added q-chip component for private rooms
- Used outline variant to distinguish from public rooms
- Maintained consistent size and color scheme
- Added proper conditional rendering
- Kept existing layout structure

## Related Issues
Closes #5 