### PR TITLE
chore: configure firebase emulator for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,31 @@
-# Chat App (chat-app)
+# Ahmad Chat App
 
-A Quasar Project
+A side project I started as I was too excited to get started with our scrum project, [MSU-Students/student-advising-portal](https://github.com/MSU-Students/student-advising-portal).
 
-## Install the dependencies
+## Development
+
+Make sure `firebase-tools` is installed on your machine with:
+
 ```bash
-yarn
-# or
-npm install
+npm i -g firebase-tools
 ```
 
-### Start the app in development mode (hot-code reloading, error reporting, etc.)
+And have your Firebase emulators started with:
+
 ```bash
+firebase emulators:start
+```
+
+Then set your environment variable to development in order to use the emulators instead of the servers:
+
+```bash
+set NODE_ENV "development"
+```
+
+And blast off!
+
+```bash
+npm run dev
+# or
 quasar dev
 ```
-
-
-### Lint the files
-```bash
-yarn lint
-# or
-npm run lint
-```
-
-
-### Format the files
-```bash
-yarn format
-# or
-npm run format
-```
-
-
-
-### Build the app for production
-```bash
-quasar build
-```
-
-### Customize the configuration
-See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-vite/quasar-config-js).

--- a/src/boot/firebase.ts
+++ b/src/boot/firebase.ts
@@ -1,7 +1,11 @@
 import { FirebaseApp, initializeApp } from 'firebase/app';
-import { collection, getFirestore } from 'firebase/firestore';
+import {
+  collection,
+  connectFirestoreEmulator,
+  getFirestore,
+} from 'firebase/firestore';
+import { connectAuthEmulator, getAuth } from 'firebase/auth';
 import { boot } from 'quasar/wrappers';
-//// import admin from 'firebase-admin';
 
 // "async" is optional;
 // more info on params: https://v2.quasar.dev/quasar-cli/boot-files
@@ -14,17 +18,31 @@ export const firebaseApp: FirebaseApp = initializeApp({
   appId: '1:389289109657:web:108810f32e48bc83b63008',
   measurementId: 'G-WCLYN8BQ3J',
 });
-//// export const serviceAccount = require(`../../${process.env.FIREBASE_ADMIN_SDK}`);
-
-//// admin.initializeApp({
-////   credential: admin.credential.cert(serviceAccount),
-//// });
 
 export default boot(async () => {});
 
+const auth = getAuth(firebaseApp);
 export const db = getFirestore(firebaseApp);
 export const chatroomsCol = collection(db, 'chatrooms');
 export const usersCol = collection(db, 'users');
 export const messagesCol = (id: string) => {
   return collection(db, `chatrooms/${id}/messages`);
 };
+
+const emulatorPorts = {
+  auth: 'http://localhost:9099',
+  firestore: {
+    host: 'localhost',
+    port: 8080,
+  },
+};
+
+const useEmulator = process.env.NODE_ENV == 'development';
+if (useEmulator) {
+  connectAuthEmulator(auth, emulatorPorts.auth);
+  connectFirestoreEmulator(
+    db,
+    emulatorPorts.firestore.host,
+    emulatorPorts.firestore.port
+  );
+}


### PR DESCRIPTION
# Configure firebase to use emulators in development

## Changes
- Configured firebase to use emulators when NODE_ENV is set to "development"
- Updated README to include instructions on setting up development environments